### PR TITLE
fix CATS-1676 relocate transporter link from setting to procurement. Removed tranporter from admin settings to its own policy

### DIFF
--- a/app/controllers/transporters_controller.rb
+++ b/app/controllers/transporters_controller.rb
@@ -1,7 +1,6 @@
 class TransportersController < ApplicationController
   before_action :set_transporter, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
-    include Administrated
   # GET /transporters
   # GET /transporters.json
   def index

--- a/app/views/layouts/_settingnav.html.erb
+++ b/app/views/layouts/_settingnav.html.erb
@@ -13,9 +13,6 @@
            <li class="<%= 'active' if is_active_controller('organizations') %>">
               <%= link_to t(:organizations), organizations_path %>
           </li>
-          <li class="<%= 'active' if is_active_controller('transporters') %>">
-              <%= link_to t(:transporters), transporters_path %>
-          </li>
         </span>
       </a>
     </li>

--- a/app/views/transporters/index.html.erb
+++ b/app/views/transporters/index.html.erb
@@ -49,7 +49,7 @@
               <%if policy(Transporter).show? %>
                   <td><%= link_to transporter.name, transporter_path(transporter) %></td>
               <%else%>
-                  <td><%= transporter_path(transporter) %></td>
+                   <td><%= transporter.name %></td>
               <% end %>
               <td><%= transporter.code %></td>
               <td><%= transporter.vehicle_count %></td>

--- a/lib/tasks/permission.rake
+++ b/lib/tasks/permission.rake
@@ -1,0 +1,9 @@
+namespace :cats do
+	namespace :permission do
+		desc "Add new permission entity to permission table"
+		task permission_items: :environment do
+			Permission.create({:name => 'Transporters'})
+			puts "Added new permission items to the database."
+		end
+	end
+end


### PR DESCRIPTION
- added a rails task to enter a new permission in to the database instead of using the already seed data
